### PR TITLE
Feature/163995942 configurable delay messages variable

### DIFF
--- a/packages/rocketchat-channel-settings/package.js
+++ b/packages/rocketchat-channel-settings/package.js
@@ -34,6 +34,7 @@ Package.onUse(function(api) {
 		'server/functions/saveRoomReadOnly.js',
 		'server/functions/saveRoomDescription.js',
 		'server/functions/saveRoomSystemMessages.js',
+		'server/functions/saveRoomMessageDelay.js',
 		'server/methods/saveRoomSettings.js',
 		'server/models/Messages.js',
 		'server/models/Rooms.js',

--- a/packages/rocketchat-channel-settings/server/functions/saveRoomMessageDelay.js
+++ b/packages/rocketchat-channel-settings/server/functions/saveRoomMessageDelay.js
@@ -1,0 +1,11 @@
+import { Meteor } from 'meteor/meteor';
+import { Match } from 'meteor/check';
+
+RocketChat.saveRoomMessageDelay = function(rid, messageDelay) {
+	if (!Match.test(rid, String)) {
+		throw new Meteor.Error('invalid-room', 'Invalid room', {
+			function: 'RocketChat.saveRoomMessageDelay',
+		});
+	}
+	return RocketChat.models.Rooms.setMessageDelayById(rid, messageDelay);
+};

--- a/packages/rocketchat-channel-settings/server/models/Rooms.js
+++ b/packages/rocketchat-channel-settings/server/models/Rooms.js
@@ -63,3 +63,16 @@ RocketChat.models.Rooms.setSystemMessagesById = function(_id, systemMessages) {
 	};
 	return this.update(query, update);
 };
+
+RocketChat.models.Rooms.setMessageDelayById = function(_id, messageDelay) {
+	const query = {
+		_id,
+	};
+	const update = {
+		$set: {
+			messageDelayType: messageDelay.messageDelayType,
+			messageDelayMS: messageDelay.messageDelayMS
+		},
+	};
+	return this.update(query, update);
+};

--- a/packages/rocketchat-lib/server/functions/createRoom.js
+++ b/packages/rocketchat-lib/server/functions/createRoom.js
@@ -43,8 +43,12 @@ RocketChat.createRoom = function(type, name, owner, members, readOnly, extraData
 		sysMes: readOnly !== true,
 	});
 
-	if(extraData.messageDelayMS) {
-		room.messageDelayMS = extraData.messageDelayMS;
+	if(extraData.messageDelayType) {
+		room.messageDelayType = extraData.messageDelayType;
+
+		if(extraData.messageDelayType == 'custom' && extraData.messageDelayMS) {
+			room.messageDelayMS = extraData.messageDelayMS;
+		}
 	}
 
 	if (type === 'd') {

--- a/packages/rocketchat-lib/server/functions/createRoom.js
+++ b/packages/rocketchat-lib/server/functions/createRoom.js
@@ -43,6 +43,10 @@ RocketChat.createRoom = function(type, name, owner, members, readOnly, extraData
 		sysMes: readOnly !== true,
 	});
 
+	if(extraData.messageDelayMS) {
+		room.messageDelayMS = extraData.messageDelayMS;
+	}
+
 	if (type === 'd') {
 		room.usernames = members;
 	}

--- a/packages/rocketchat-lib/server/functions/sendMessage.js
+++ b/packages/rocketchat-lib/server/functions/sendMessage.js
@@ -75,9 +75,6 @@ const validateAttachment = (attachment) => {
 
 const validateBodyAttachments = (attachments) => attachments.map(validateAttachment);
 
-const TenMinutesInMS = 600000;
-const DefaultMessageDelay = TenMinutesInMS;
-
 const DelayMessage = (MS) => Meteor._sleepForMs(MS);
 
 RocketChat.sendMessage = function(user, message, room, upsert = false) {
@@ -85,11 +82,13 @@ RocketChat.sendMessage = function(user, message, room, upsert = false) {
 		return false;
 	}
 
-   if(room.messageDelayMS) {
+    if(room.messageDelayType === 'custom' && room.messageDelayMS) {
 		DelayMessage(room.messageDelayMS);
-   } else {
+    } else {	   
+		const DefaultMessageDelay = RocketChat.settings.get('Message_DefaultDelayMS');
+		
 		DelayMessage(DefaultMessageDelay);
-   }
+    }
 
 	check(message, objectMaybeIncluding({
 		_id: String,

--- a/packages/rocketchat-lib/server/functions/sendMessage.js
+++ b/packages/rocketchat-lib/server/functions/sendMessage.js
@@ -75,13 +75,21 @@ const validateAttachment = (attachment) => {
 
 const validateBodyAttachments = (attachments) => attachments.map(validateAttachment);
 
+const TenMinutesInMS = 600000;
+const DefaultMessageDelay = TenMinutesInMS;
+
+const DelayMessage = (MS) => Meteor._sleepForMs(MS);
+
 RocketChat.sendMessage = function(user, message, room, upsert = false) {
 	if (!user || !message || !room._id) {
 		return false;
 	}
 
-        // Adding 10 minutes delay for every message.
-	Meteor._sleepForMs(600000);
+   if(room.messageDelayMS) {
+		DelayMessage(room.messageDelayMS);
+   } else {
+		DelayMessage(DefaultMessageDelay);
+   }
 
 	check(message, objectMaybeIncluding({
 		_id: String,

--- a/packages/rocketchat-ui-admin/client/rooms/adminRoomInfo.html
+++ b/packages/rocketchat-ui-admin/client/rooms/adminRoomInfo.html
@@ -78,6 +78,24 @@
 								</div>
 							</li>
 						{{/if}}
+						<li>
+							<label>Message Delay</label>
+							<div>
+								{{#if editing 'messageDelay'}}
+									<label><input type="radio" name="messageDelayType" class="editing" value="Default" checked="{{$eq messageDelayType 'Default'}}" /> Default</label>
+									<label>
+										<input type="radio" name="messageDelayType" value="Custom" checked="{{$eq messageDelayType 'Custom'}}" /> Custom 
+										{{#if isCustomMessageDelay }}
+											<input name="messageDelayMS" type="number" value="{{messageDelayMS}}" />
+										{{/if}}
+									</label>
+									<button type="button" class="button cancel">{{_ "Cancel"}}</button>
+									<button type="button" class="button primary save">{{_ "Save"}}</button>
+								{{else}}
+									<span>{{messageDelayType}}{{#if isCustomMessageDelay}}, {{/if}} {{messageDelayMS}}{{#if canEdit}} <i class="icon-pencil" data-edit="messageDelay"></i>{{/if}}</span>
+								{{/if}}
+							</div>
+						</li>
 						{{#each channelSettings}}
 							{{> Template.dynamic template=template data=data}}
 						{{/each}}

--- a/packages/rocketchat-ui-admin/publications/adminRooms.js
+++ b/packages/rocketchat-ui-admin/publications/adminRooms.js
@@ -27,6 +27,8 @@ Meteor.publish('adminRooms', function(filter, types, limit) {
 			msgs: 1,
 			archived: 1,
 			tokenpass: 1,
+			messageDelayType: 1,
+			messageDelayMS: 1
 		},
 		limit,
 		sort: {

--- a/packages/rocketchat-ui/client/views/app/createChannel.html
+++ b/packages/rocketchat-ui/client/views/app/createChannel.html
@@ -90,6 +90,44 @@
 					</div>
 					<div class="rc-input">
 						<label class="rc-input__label">
+							<div class="rc-input__title">Message Delay Type</div>
+							<div class="rc-input__wrapper">
+								<div class="rc-select">
+									<select class="input-monitor rc-select__element" name="messageDelayType">
+										<option value="default" selected>Default</option>
+										<option value="custom">Custom</option>
+									</select>
+									<svg class="rc-icon rc-select__arrow rc-select__arrow--arrow-down" aria-hidden="true">
+										<use xlink:href="#icon-arrow-down"></use>
+									</svg>
+								</div>
+							</div>
+						</label>
+					</div>
+					{{#if isCustomMessageDelay}}
+					<div class="rc-input  {{#if invalidMessageDelay}}rc-input--error{{/if}}">
+						<label class="rc-input__label">
+							<div class="rc-input__title">Custom Message Delay</div>
+							<div class="rc-input__wrapper">
+								<div class="rc-input__icon">
+									{{> icon block="rc-input__icon-svg" icon="clock" }}
+								</div>
+								<input name="messageDelay" type="number" class="rc-input__element"
+										placeholder="Please enter channel message delay..." autofocus>
+							</div>
+						</label>
+						{{#if invalidMessageDelay}}
+							<div class="rc-input__error">
+								<div class="rc-input__error-icon">
+									{{> icon block="rc-input__error-icon" icon="warning" classes="rc-input__error-icon-svg"}}
+								</div>
+								<div class="rc-input__error-message">Message delay must be a positive integer.</div>
+							</div>
+						{{/if}}
+					</div>
+					{{/if}}
+					<div class="rc-input">
+						<label class="rc-input__label">
 							<div class="rc-input__title">{{_ "Invite_Users"}}</div>
 							<div class="rc-input__wrapper">
 								<div class="rc-input__icon">

--- a/packages/rocketchat-ui/client/views/app/createChannel.js
+++ b/packages/rocketchat-ui/client/views/app/createChannel.js
@@ -209,7 +209,7 @@ Template.createChannel.events({
 	'input [name="messageDelay"]'(e, t) {
 		const input = e.target;
 		const modified = Math.round(input.value);
-		console.log('old', e.target.value, 'new', modified);
+
 		input.value = modified;
 		document.activeElement === input && e && /input/i.test(e.type);
 		t.invalidMessageDelay.set(!validateMessageDelay(input.value));

--- a/packages/rocketchat-ui/client/views/app/createChannel.js
+++ b/packages/rocketchat-ui/client/views/app/createChannel.js
@@ -41,6 +41,10 @@ const validateChannelName = (name) => {
 	return name.length === 0 || reg.test(name);
 };
 
+const validateMessageDelay = (delay) => {
+	return delay >= 0;
+}
+
 const filterNames = (old) => {
 	if (RocketChat.settings.get('UI_Allow_room_names_with_special_chars')) {
 		return old;
@@ -83,6 +87,15 @@ Template.createChannel.helpers({
 		const invalid = instance.invalid.get();
 		const inUse = instance.inUse.get();
 		return invalid || inUse;
+	},
+	invalidMessageDelay() {
+		const instance = Template.instance();
+		const invalid = instance.invalidMessageDelay.get();
+		return invalid;
+	},
+	isCustomMessageDelay() {
+		const instance = Template.instance();
+		return instance.isCustomMessageDelay.get();
 	},
 	typeLabel() {
 		return t(Template.instance().type.get() === 'p' ? t('Private_Channel') : t('Public_Channel'));
@@ -189,6 +202,21 @@ Template.createChannel.events({
 	'change [name="readOnly"]'(e, t) {
 		t.readOnly.set(e.target.checked);
 	},
+	'input [name="messageDelayType"]'(e, t) {
+		t.messageDelayType.set(e.target.value);
+		t.isCustomMessageDelay.set(e.target.value === 'custom');
+	},
+	'input [name="messageDelay"]'(e, t) {
+		const input = e.target;
+		const modified = Math.round(input.value);
+		console.log('old', e.target.value, 'new', modified);
+		input.value = modified;
+		document.activeElement === input && e && /input/i.test(e.type);
+		t.invalidMessageDelay.set(!validateMessageDelay(input.value));
+		if (input.value !== t.messageDelay.get()) {
+			t.messageDelay.set(modified);
+		}
+	},
 	'input [name="users"]'(e, t) {
 		const input = e.target;
 		const position = input.selectionEnd || input.selectionStart;
@@ -222,17 +250,22 @@ Template.createChannel.events({
 		const readOnly = instance.readOnly.get();
 		const broadcast = instance.broadcast.get();
 		const encrypted = instance.encrypted.get();
+		const messageDelay = instance.messageDelay.get();
+		const messageDelayType = instance.messageDelayType.get();
 		const isPrivate = type === 'p';
 
 		if (instance.invalid.get() || instance.inUse.get()) {
 			return e.target.name.focus();
+		}
+		if(instance.invalidMessageDelay.get()) {
+			return e.target.messageDelay.focus();
 		}
 		if (!Object.keys(instance.extensions_validations).map((key) => instance.extensions_validations[key]).reduce((valid, fn) => fn(instance) && valid, true)) {
 			return instance.extensions_invalid.set(true);
 		}
 
 		const extraData = Object.keys(instance.extensions_submits)
-			.reduce((result, key) => ({ ...result, ...instance.extensions_submits[key](instance) }), { broadcast, encrypted });
+			.reduce((result, key) => ({ ...result, ...instance.extensions_submits[key](instance) }), { broadcast, encrypted, messageDelayMS: messageDelay, messageDelayType });
 
 		Meteor.call(isPrivate ? 'createPrivateGroup' : 'createChannel', name, instance.selectedUsers.get().map((user) => user.username), readOnly, {}, extraData, function(err, result) {
 			if (err) {
@@ -280,6 +313,10 @@ Template.createChannel.onCreated(function() {
 	this.extensions_submits = {};
 	this.name = new ReactiveVar('');
 	this.type = new ReactiveVar(RocketChat.authz.hasAllPermission(['create-p']) ? 'p' : 'c');
+	this.messageDelay = new ReactiveVar('');
+	this.invalidMessageDelay = new ReactiveVar(false);
+	this.messageDelayType = new ReactiveVar('default');
+	this.isCustomMessageDelay = new ReactiveVar(false);
 	this.readOnly = new ReactiveVar(false);
 	this.broadcast = new ReactiveVar(false);
 	this.encrypted = new ReactiveVar(false);


### PR DESCRIPTION
[NEW] Feature/configurable delay messages variable

Closes #163995942 

* Added 'messageDelayMS', 'messageDelayType' fields for rooms schema in DB.

* Added 'message delay type' and 'custom message delay' fields for 'create a new channel' window:
![image](https://user-images.githubusercontent.com/21021560/52512749-40837780-2c0f-11e9-8b60-45f59f853b19.png)

* Added 'message delay' field for 'Room Info' window in Administration section:
![image](https://user-images.githubusercontent.com/21021560/52512791-83454f80-2c0f-11e9-8355-aaa122693aba.png)
