### PR TITLE
Feature/163995942 configurable delay messages variable

### DIFF
--- a/packages/rocketchat-ui-admin/client/rooms/adminRoomInfo.html
+++ b/packages/rocketchat-ui-admin/client/rooms/adminRoomInfo.html
@@ -92,7 +92,7 @@
 									<button type="button" class="button cancel">{{_ "Cancel"}}</button>
 									<button type="button" class="button primary save">{{_ "Save"}}</button>
 								{{else}}
-									<span>{{messageDelayType}}{{#if isCustomMessageDelay}}, {{/if}} {{messageDelayMS}}{{#if canEdit}} <i class="icon-pencil" data-edit="messageDelay"></i>{{/if}}</span>
+									<span>{{messageDelayType}}{{#if isCustomMessageDelay}}, {{messageDelayMS}}{{/if}}{{#if canEdit}} <i class="icon-pencil" data-edit="messageDelay"></i>{{/if}}</span>
 								{{/if}}
 							</div>
 						</li>

--- a/packages/rocketchat-ui-admin/client/rooms/adminRoomInfo.js
+++ b/packages/rocketchat-ui-admin/client/rooms/adminRoomInfo.js
@@ -304,7 +304,7 @@ Template.adminRoomInfo.onCreated(function() {
 				}
 
 				const messageDelay = {
-					messageDelayType: this.messageDelayType.get(),
+					messageDelayType: this.messageDelayType.get().toLowerCase(),
 					messageDelayMS: this.messageDelayMS.get()
 				};
 


### PR DESCRIPTION
[FIX] Fixed bug of use default delay instead of custom delay in case of changing delay type from administration window.

![image](https://user-images.githubusercontent.com/21021560/60761113-b3700d80-a04a-11e9-8b31-2820e4944cc6.png)

